### PR TITLE
fix: small improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,7 +459,7 @@ dependencies = [
 
 [[package]]
 name = "piano-analytics-component"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piano-analytics-component"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 
 [lib]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,9 +26,14 @@ impl Guest for PianoComponent {
                 PianoEvent::new("page.display", &edgee_event).map_err(|e| e.to_string())?;
 
             event.data.pageview_id = Some(edgee_event.uuid.clone());
-            event.data.page_name = Some(data.name.clone());
-            event.data.content_title = Some(data.title.clone());
-            event.data.page_title_html = Some(data.title.clone());
+            if !data.name.is_empty() {
+                event.data.page_name = Some(data.name.clone());
+            }
+            if !data.title.is_empty() {
+                event.data.content_title = Some(data.title.clone());
+                event.data.page_title_html = Some(data.title.clone());
+                event.data.page = Some(data.title.clone());
+            }
             event.data.content_keywords = Some(data.keywords.clone());
             event.data.event_url_full = Some(data.url.clone());
             event.data.previous_url = Some(data.referrer.clone());


### PR DESCRIPTION
- "Not;A=Brand" could not be added to ch_ua and ch_ua_full_version_list
- `device_local_hour` and `device_timestamp_utc` have to be to be timestamps with milliseconds 
- Missing `page` field
- Do not set `page_name` if it’s null
- capitalize `browser_language_local`