### PR TITLE
feat: new wit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,7 +656,7 @@ dependencies = [
 
 [[package]]
 name = "piano-analytics-component"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "cargo-llvm-cov",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piano-analytics-component"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This component implements the data collection protocol between [Edgee](https://w
 3. Add the following configuration to your `edgee.toml`:
 
 ```toml
-[[destinations.data_collection]]
-name = "piano"
-component = "/var/edgee/components/piano.wasm"
-credentials.piano_site_id = "..."
-credentials.piano_collection_domain = "..."
+[[components.data_collection]]
+id = "piano"
+file = "/var/edgee/components/piano.wasm"
+settings.piano_site_id = "..."
+settings.piano_collection_domain = "..."
 ```
 
 ## Event Handling
@@ -48,23 +48,23 @@ While User events don't generate Piano Analytics events directly, they serve an 
 
 ### Basic Configuration
 ```toml
-[[destinations.data_collection]]
-name = "piano"
-component = "/var/edgee/components/piano.wasm"
-credentials.piano_site_id = "..."
-credentials.piano_collection_domain = "..."
+[[components.data_collection]]
+id = "piano"
+file = "/var/edgee/components/piano.wasm"
+settings.piano_site_id = "..."
+settings.piano_collection_domain = "..."
 
 # Optional configurations
-config.anonymization = true        # Enable/disable data anonymization in case of pending or denied consent
-config.default_consent = "pending" # Set default consent status if not specified by the user
+settings.edgee_anonymization = true        # Enable/disable data anonymization in case of pending or denied consent
+settings.edgee_default_consent = "pending" # Set default consent status if not specified by the user
 ```
 
 ### Event Controls
 Control which events are forwarded to Piano Analytics:
 ```toml
-config.page_event_enabled = true   # Enable/disable page event
-config.track_event_enabled = true  # Enable/disable track event
-config.user_event_enabled = true   # Enable/disable user event
+settings.edgee_page_event_enabled = true   # Enable/disable page event
+settings.edgee_track_event_enabled = true  # Enable/disable track event
+settings.edgee_user_event_enabled = true   # Enable/disable user event
 ```
 
 ### Consent Management

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,10 +16,10 @@ export!(PianoComponent);
 struct PianoComponent;
 
 impl Guest for PianoComponent {
-    fn page(edgee_event: Event, cred_map: Dict) -> Result<EdgeeRequest, String> {
+    fn page(edgee_event: Event, settings: Dict) -> Result<EdgeeRequest, String> {
         if let Data::Page(ref data) = edgee_event.data {
             let mut payload =
-                PianoPayload::new(&edgee_event, cred_map).map_err(|e| e.to_string())?;
+                PianoPayload::new(&edgee_event, settings).map_err(|e| e.to_string())?;
 
             // page_view event
             let mut event =
@@ -62,14 +62,14 @@ impl Guest for PianoComponent {
         }
     }
 
-    fn track(edgee_event: Event, cred_map: Dict) -> Result<EdgeeRequest, String> {
+    fn track(edgee_event: Event, settings: Dict) -> Result<EdgeeRequest, String> {
         if let Data::Track(ref data) = edgee_event.data {
             if data.name.is_empty() {
                 return Err("Missing event name".to_string());
             }
 
             let mut payload =
-                PianoPayload::new(&edgee_event, cred_map).map_err(|e| e.to_string())?;
+                PianoPayload::new(&edgee_event, settings).map_err(|e| e.to_string())?;
 
             // event
             let mut event =
@@ -93,7 +93,7 @@ impl Guest for PianoComponent {
         }
     }
 
-    fn user(_edgee_event: Event, _cred_map: Dict) -> Result<EdgeeRequest, String> {
+    fn user(_edgee_event: Event, _settings: Dict) -> Result<EdgeeRequest, String> {
         Err("User event not mapped to Piano Analytics".to_string())
     }
 }
@@ -109,6 +109,7 @@ fn build_edgee_request(piano_payload: PianoPayload) -> EdgeeRequest {
             piano_payload.collection_domain, piano_payload.site_id, piano_payload.id_client
         ),
         headers,
+        forward_client_headers: true,
         body: serde_json::to_string(&piano_payload).unwrap(),
     }
 }
@@ -279,7 +280,7 @@ mod tests {
         "ABCDEFG.pa-cd.com".to_string()
     }
 
-    fn sample_credentials() -> Vec<(String, String)> {
+    fn sample_settings() -> Vec<(String, String)> {
         vec![
             ("piano_site_id".to_string(), "abc".to_string()),
             (
@@ -298,8 +299,8 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials = sample_credentials();
-        let result = PianoComponent::page(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::page(event, settings);
 
         assert_eq!(result.is_err(), false);
         let edgee_request = result.unwrap();
@@ -323,8 +324,8 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials = sample_credentials();
-        let result = PianoComponent::page(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::page(event, settings);
 
         assert_eq!(result.is_err(), false);
         let edgee_request = result.unwrap();
@@ -341,8 +342,8 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials = sample_credentials();
-        let result = PianoComponent::page(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::page(event, settings);
 
         assert_eq!(result.is_err(), false);
         let edgee_request = result.unwrap();
@@ -360,8 +361,8 @@ mod tests {
             true,
         );
 
-        let credentials = sample_credentials();
-        let result = PianoComponent::page(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::page(event, settings);
 
         assert_eq!(result.is_err(), false);
         let edgee_request = result.unwrap();
@@ -379,8 +380,8 @@ mod tests {
             true,
         );
 
-        let credentials = sample_credentials();
-        let result = PianoComponent::page(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::page(event, settings);
 
         assert_eq!(result.is_err(), false);
         let edgee_request = result.unwrap();
@@ -397,8 +398,8 @@ mod tests {
             "CET".to_string(),
             false,
         );
-        let credentials = sample_credentials();
-        let result = PianoComponent::page(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::page(event, settings);
 
         assert_eq!(result.is_err(), false);
         let edgee_request = result.unwrap();
@@ -415,8 +416,8 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials: Vec<(String, String)> = vec![]; // empty
-        let result = PianoComponent::page(event, credentials); // this should panic!
+        let settings: Vec<(String, String)> = vec![]; // empty
+        let result = PianoComponent::page(event, settings); // this should panic!
         assert_eq!(result.is_err(), true);
     }
 
@@ -429,10 +430,10 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials: Vec<(String, String)> = vec![
+        let settings: Vec<(String, String)> = vec![
             ("piano_site_id".to_string(), "abc".to_string()), // only site ID
         ];
-        let result = PianoComponent::page(event, credentials); // this should panic!
+        let result = PianoComponent::page(event, settings); // this should panic!
         assert_eq!(result.is_err(), true);
     }
 
@@ -446,8 +447,8 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials = sample_credentials();
-        let result = PianoComponent::track(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::track(event, settings);
         assert_eq!(result.clone().is_err(), false);
         let edgee_request = result.unwrap();
         assert_eq!(edgee_request.method, HttpMethod::Post);
@@ -464,8 +465,8 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials = sample_credentials();
-        let result = PianoComponent::track(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::track(event, settings);
         assert_eq!(result.is_err(), true);
     }
 
@@ -478,8 +479,8 @@ mod tests {
             "CET".to_string(),
             true,
         );
-        let credentials = sample_credentials();
-        let result = PianoComponent::user(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::user(event, settings);
 
         assert_eq!(result.clone().is_err(), true);
         assert_eq!(
@@ -505,8 +506,8 @@ mod tests {
         );
         event.context.user.properties = vec![]; // empty context user properties
         event.context.user.user_id = "".to_string(); // empty context user id
-        let credentials = sample_credentials();
-        let result = PianoComponent::track(event, credentials);
+        let settings = sample_settings();
+        let result = PianoComponent::track(event, settings);
         //println!("Error: {}", result.clone().err().unwrap().to_string().as_str());
         assert_eq!(result.clone().is_err(), false);
     }

--- a/src/piano_payload.rs
+++ b/src/piano_payload.rs
@@ -17,8 +17,8 @@ pub(crate) struct PianoPayload {
 }
 
 impl PianoPayload {
-    pub(crate) fn new(edgee_event: &Event, cred_map: Dict) -> anyhow::Result<Self> {
-        let cred: HashMap<String, String> = cred_map
+    pub(crate) fn new(edgee_event: &Event, settings: Dict) -> anyhow::Result<Self> {
+        let cred: HashMap<String, String> = settings
             .iter()
             .map(|(key, value)| (key.to_string(), value.to_string()))
             .collect();
@@ -175,6 +175,7 @@ impl PianoEvent {
         }
         if !edgee_event.context.page.search.is_empty() {
             // analyze search string
+            // todo, add utm_ and lmd_
             let qs = serde_qs::from_str(edgee_event.context.page.search.as_str());
             if qs.is_ok() {
                 let qs_map: HashMap<String, String> = qs.unwrap();

--- a/wit/deps.lock
+++ b/wit/deps.lock
@@ -1,4 +1,4 @@
 [protocols]
-url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
-sha256 = "4d412367fff6f826280acbe95f7067e362d9299d76e60994981e7e27c74d1576"
-sha512 = "65021cace5ed07990fdfb563699accb975a31cb22311739ff6189849b969b06b564a0f8f72de154fd086ba474757d3cffaef0175778e4989c467280cf1c86284"
+url = "https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"
+sha256 = "8b5c8ea97c81d1d6cf4f227e75afb8c4dc5c0a411c3a0401fb7e4f7b745e21ba"
+sha512 = "16771cd12095409e7c4857a8f5c0b4ad680959e3c35dcd7999e11131bcce05d3b1a1b829daefceabbd853ae5b7f6453e3e359ddfbdebd6e2a94db6c55780368f"

--- a/wit/deps.toml
+++ b/wit/deps.toml
@@ -1,1 +1,1 @@
-protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.3.0.tar.gz"
+protocols="https://github.com/edgee-cloud/edgee-wit/archive/refs/tags/v0.4.0.tar.gz"

--- a/wit/deps/protocols/consent-mapping.wit
+++ b/wit/deps/protocols/consent-mapping.wit
@@ -1,7 +1,7 @@
 package edgee:protocols;
 
 interface consent-mapping {
-    type config = list<tuple<string,string>>;
+    type dict = list<tuple<string,string>>;
 
     enum consent {
         pending,
@@ -9,5 +9,5 @@ interface consent-mapping {
         denied,
     }
 
-    map: func(cookie: string, config: config) -> option<consent>;
+    map: func(cookie: string, settings: dict) -> option<consent>;
 }

--- a/wit/deps/protocols/data-collection.wit
+++ b/wit/deps/protocols/data-collection.wit
@@ -102,12 +102,13 @@ interface data-collection {
         method: http-method,
         url: string,
         headers: dict,
+        forward-client-headers: bool,
         body: string,
     }
 
     enum http-method { GET, PUT, POST, DELETE }
 
-    page: func(e: event, cred: dict) -> result<edgee-request, string>;
-    track: func(e: event, cred: dict) -> result<edgee-request, string>;
-    user: func(e: event, cred:dict) -> result<edgee-request, string>;
+    page: func(e: event, settings: dict) -> result<edgee-request, string>;
+    track: func(e: event, settings: dict) -> result<edgee-request, string>;
+    user: func(e: event, settings:dict) -> result<edgee-request, string>;
 }


### PR DESCRIPTION
New wit protocol

- `edgee-request` has now a new field `forward-client-headers`
- change `credentials` with `settings`
- Adapt Readme to reflect latest toml changes