### PR TITLE
WIP - Validate that context data is not being used for page event

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,16 @@ impl Guest for PianoComponent {
             )
             .map_err(|e| e.to_string())?;
 
+            if !edgee_event.context.page.title.is_empty() {
+                event.data.page_title_html = Some(edgee_event.context.page.title.clone());
+                event.data.content_title = Some(edgee_event.context.page.title.clone());
+                event.data.page = Some(edgee_event.context.page.title.clone());
+            }
+
+            if !edgee_event.context.page.path.is_empty() {
+                event.data.page = Some(data.name.clone());
+            }
+
             // add custom page properties
             if !data.properties.is_empty() {
                 for (key, value) in data.properties.clone().iter() {


### PR DESCRIPTION
### Description of Changes

The Piano component is not correctly using `context.page`.

Our [documentation](https://www.edgee.cloud/docs/services/data-collection/data-layer) says:

> Note: when you define context data about the current page or user, it’s going to be used automatically for all compatible events, so you don’t need to provide the same information multiple times. For example, data_collection.context.user is used to define the data fields for user events.

This PR adds a test to validate that the component is not behaving as intended (by focusing on `page.properties` only). It will need some more work to make sure we're merging all the page data as well.
